### PR TITLE
Changed hook_preprocess() to template_preprocess_HOOK()

### DIFF
--- a/theme/theme.inc
+++ b/theme/theme.inc
@@ -6,9 +6,9 @@
  */
 
 /**
- * Implements hook_preprocess().
+ * Implements template_preprocess_HOOK().
  */
-function islandora_web_archive_preprocess_islandora_web_archive(array &$variables) {
+function template_preprocess_islandora_web_archive(array &$variables) {
   module_load_include('inc', 'islandora', 'includes/datastream');
   module_load_include('inc', 'islandora', 'includes/utilities');
   module_load_include('inc', 'islandora', 'includes/solution_packs');


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-1071

# What does this Pull Request do?

This pull request ensures that when a function in this module implements hook_theme() that the template_preprocess hook is called to allow overriding variables further down the processing chain.

# What's new?

A function name has been changed to begin with ‘template’ instead of islandora_web_archive.

# Interested parties

@Islandora/7-x-1-x-committers