### PR TITLE
ISLANDORA-2349 changes to pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,6 @@
+!!!!!! PLEASE NOTE: The text below is a template to give us the information we need to act on your pull request. Please delete or mark N/A on any questions that do not apply to your pull request. Please DO NOT leave the default text OR this text in place when you submit your pull request!!!!!!
+
+
 **JIRA Ticket**: (link)
 
 * Other Relevant Links (Google Groups discussion, related pull requests, Release pull requests, etc.)
@@ -27,10 +30,11 @@ A description of what steps someone could take to:
 Any additional information that you think would be helpful when reviewing this PR.
 
 Example:
-* Does this change require documentation to be updated? 
+* Does this change the interface, add a new feature, or otherwise change behaviours that would require updating documentation? 
 * Does this change add any new dependencies? 
 * Does this change require any other modifications to be made to the repository (ie. Regeneration activity, etc.)? 
 * Could this change impact execution of existing code?
 
 # Interested parties
 Tag (@ mention) interested parties or, if unsure, @Islandora/7-x-1-x-committers
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -37,4 +37,3 @@ Example:
 
 # Interested parties
 Tag (@ mention) interested parties or, if unsure, @Islandora/7-x-1-x-committers
-


### PR DESCRIPTION
**JIRA Ticket**: https://jira.duraspace.org/browse/ISLANDORA-2349

# What does this Pull Request do?

Two changes to the pull request template:
1. New text at the top to warn the unwary to not leave all of the default text in place when submitting a pull request. Lots of !!!! and CAPS because it has to be noticeable in the *edit* screen, not when published.
1. Expanding the "does this need documentation" text to include examples and cut down on false negatives.

This was discussed at the November 29th Committers call, with a test PR confirmed and merged on Jan 10 2019. 

# What's new?
A new warning at the top of the PR template and a small change in the body.

# Interested parties
@Islandora/7-x-1-x-committers 