### PR TITLE
Update self-transform for consistency with other SPs

### DIFF
--- a/islandora_web_archive.module
+++ b/islandora_web_archive.module
@@ -110,7 +110,7 @@ function islandora_web_archive_xml_form_builder_form_associations() {
         'titleInfo', 'title',
       ),
       'transform' => 'mods_to_dc.xsl',
-      'self_transform' => 'cleanup_mods.xsl',
+      'self_transform' => 'islandora_cleanup_mods_extended.xsl',
       'template' => FALSE,
     ),
   );


### PR DESCRIPTION
**JIRA Ticket**: (https://jira.duraspace.org/browse/ISLANDORA-2383)

# What does this Pull Request do?

Updates the cleanup self-transform to the Web Archive SP default form association. Provides a cleaner MODS xml datastream.

This is/will be one of many similar updates, as all of the stock forms should receive this association.

# How should this be tested?
* Check out the branch
* Review the form association (form builder -> enabled associations)
* Ingest a test object with a lot of blank metadata fields and review the resulting MODS XML, see clean XML without empty elements

# Interested parties
@Islandora/7-x-1-x-committers